### PR TITLE
Add WeJob.ch

### DIFF
--- a/paises/suica/suica.md
+++ b/paises/suica/suica.md
@@ -18,4 +18,5 @@
 » [Swiss Dev Jobs](https://swissdevjobs.ch)\
 » [The Stamford Group](http://thestamfordgroup.com)\
 » [Treff Punkt](https://www.treffpunkt-arbeit.ch/home/job-seeker)\
+» [WeJob.ch](https://wejob.ch)\
 » [Zeitung](http://www.zeitung.ch)


### PR DESCRIPTION
Would be great to add WeJob.ch

WeJob.ch is the #1 Platform for Developers and IT Jobs in Switzerland

We're also on:

- https://www.linkedin.com/company/we-job
- https://www.facebook.com/WeJobCH/
- https://twitter.com/WeJobCH
- https://t.me/wejobch/