### PR TITLE
Concerto de Typos, removidos os links inativos e concerto de links quebrados.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 
 <br />
 
-# Se Desafiem ...
+# Se Desafiem...
 
 » [Frontend Challanges](https://github.com/felipefialho/frontend-challenges)\
 » [Backend Challanges](https://github.com/CollabCodeTech/backend-challenges)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 
 <br />
 
-# Empresas no Mundo para trabalhos remotos
+# Empresas no mundo para trabalhos remotos.
 
 » [Remote Job Worldwide](https://github.com/remoteintech/remote-jobs)
 
 <br />
 
-# Empresas no Brasil para trabalhos remotos
+# Empresas no Brasil para trabalhos remotos.
 
 » [Remote Job Brazil](https://github.com/lerrua/remote-jobs-brazil)
 
 <br />
 
-# Sites por regiões e países
+# Sites por regiões e países.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 
 <br />
 
-# Empresas no brasil para trabalhos remotos
+# Empresas no Brasil para trabalhos remotos
 
 » [Remote Job Brazil](https://github.com/lerrua/remote-jobs-brazil)
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [18F](https://18f.gsa.gov) - USA
 - [1Password](https://www.1password.com) - North America, UK
 - [42 Technologies](https://www.42technologies.com) - Worldwide
-- [6 Figures](http://www.6figures.com) - Canada
-- [6 Nomads](https://6nomads.com/resources/remotejob) - WorldWide
+- [6 Nomads](https://6nomads.com) - WorldWide
 - [99Freelas](https://www.99freelas.com.br) - Brazil
 - [ADP Jobs](https://jobs.adp.com) - WorldWide
 - [AE Studio](https://ae.studio) - USA, BR
 - [ALICE](https://aliceplatform.com) - Worldwide
-- [ARK](https://www.ark.io/careers) - Worldwide
+- [ARK](https://www.ark.io) - Worldwide
 - [Abiturma](https://www.abiturma.de) - Germany
 - [Ably](https://www.ably.io) - Europe
 - [About you](https://corporate.aboutyou.de/en/departments/tech)
@@ -61,14 +60,10 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [Aerolab](https://aerolab.co) - Latin America
 - [AgFlow](https://www.agflow.com) - Europe
 - [Aha!](https://www.aha.io) - Worldwide
-- [Aim India](https://www.aimincorp.com) - India
 - [AirGarage](https://www.airgarage.com) - USA
 - [AirTreks](https://www.airtreks.com) - USA
 - [Airbyte](https://airbyte.com) - Europe, North America, Latin America
-- [Aivitex](https://www.aivitex.de) - Germany
-- [Algolia](https://www.algolia.com/careers)
 - [Algorand](https://www.algorand.com) - USA
-- [Algorithmia](https://algorithmia.com) - the USA or Canada
 - [Alight Solutions](https://alight.com) - Worldwide
 - [All Star Jobs](https://www.allstarjobs.ca) - Canada
 - [Alley](https://alley.co) - USA, Canada, Western Europe
@@ -100,10 +95,8 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [Audiense](https://www.audiense.com) ️- Worldwide
 - [Aula Education](https://aula.education) - Worldwide
 - [Auth0](https://auth0.com) - Worldwide
-- [Auth0](https://auth0.com/careers/positions)
 - [Authentic Jobs](http://authenticjobs.com) - WorldWide
 - [Auto Jobs](https://www.auto-jobs.ca) - Canada
-- [Autodesk](https://autodesk.rolepoint.com)
 - [Automattic](https://automattic.com) - Worldwide
 - [Automattic](https://automattic.com/work-with-us)
 - [Axelerant](https://axelerant.com) - Worldwide
@@ -280,6 +273,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [Data Science Brigade](https://dsbrigade.com) - Worldwide
 - [DataCamp](https://www.datacamp.com) - Europe or comparable timezone
 - [DataDog](https://www.datadoghq.com)
+- [DataRobot](https://algorithmia.com) - the USA or Canada
 - [DataStax](https://www.datastax.com) - Worldwide
 - [Datadog](https://www.datadoghq.com) - Worldwide
 - [Datica](https://datica.com) - USA

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 
 <br />
 
-# Empresas no Mundo para trabalhos remotosng
+# Empresas no Mundo para trabalhos remotos
 
 » [Remote Job Worldwide](https://github.com/remoteintech/remote-jobs)
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [AirGarage](https://www.airgarage.com) - USA
 - [AirTreks](https://www.airtreks.com) - USA
 - [Airbyte](https://airbyte.com) - Europe, North America, Latin America
+- [Aivitex](https://www.aivitex.de) - Germany
+- [Algolia](https://www.algolia.com/careers)
 - [Algorand](https://www.algorand.com) - USA
 - [Alight Solutions](https://alight.com) - Worldwide
 - [All Star Jobs](https://www.allstarjobs.ca) - Canada
@@ -94,7 +96,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [Astronomer](https://www.astronomer.io) - USA
 - [Audiense](https://www.audiense.com) ️- Worldwide
 - [Aula Education](https://aula.education) - Worldwide
-- [Auth0](https://auth0.com) - Worldwide
+- [Auth0](https://auth0.com/careers/positions) - Worldwide
 - [Authentic Jobs](http://authenticjobs.com) - WorldWide
 - [Auto Jobs](https://www.auto-jobs.ca) - Canada
 - [Automattic](https://automattic.com) - Worldwide
@@ -273,7 +275,7 @@ Administrador » Anderson Martins » [atmmoreira.rj@gmail.com](mailto:atmmoreira
 - [Data Science Brigade](https://dsbrigade.com) - Worldwide
 - [DataCamp](https://www.datacamp.com) - Europe or comparable timezone
 - [DataDog](https://www.datadoghq.com)
-- [DataRobot](https://algorithmia.com) - the USA or Canada
+- [DataRobot](https://www.datarobot.com/careers/) - the USA or Canada
 - [DataStax](https://www.datastax.com) - Worldwide
 - [Datadog](https://www.datadoghq.com) - Worldwide
 - [Datica](https://datica.com) - USA


### PR DESCRIPTION
Erros de ortografia corrigidos.

Linha 6 = Removido um espaço antes dos três pontos.
Linha 13 = "Mundo" para "mundo"; Letras a mais removidas "ng" do fim da linha; Adicionado um ponto final.
Linha 19 = "brasil" para "Brasil"; Adicionado um ponto final.
Linha 25 = Adicionado um ponto final.

Removidos os sites inativos e consertados os links quebrados de todos os iniciais e letra "A".

6 Figures (Removido)
6 Nomads (Consertado)
ARK (Consertado)
Aim India (Removido)
Aivitex (Removido)
Algolia (Removido)
Algorithmia (Site mudou para DataRobot - Concertado)
Auth0 (Removido)
AutoDesk (Removido)